### PR TITLE
add parameter [TabCloseConfirmationDialogBuilder].

### DIFF
--- a/lib/src/internal/tabbed_view_provider.dart
+++ b/lib/src/internal/tabbed_view_provider.dart
@@ -15,6 +15,7 @@ class TabbedViewProvider {
       this.contentBuilder,
       this.onTabClose,
       this.tabCloseInterceptor,
+      this.tabCloseConfirmationDialogBuilder,
       required this.contentClip,
       this.onTabSelection,
       this.tabSelectInterceptor,
@@ -34,6 +35,7 @@ class TabbedViewProvider {
   final IndexedWidgetBuilder? contentBuilder;
   final OnTabClose? onTabClose;
   final TabCloseInterceptor? tabCloseInterceptor;
+  final TabCloseConfirmationDialogBuilder? tabCloseConfirmationDialogBuilder;
   final OnTabSelection? onTabSelection;
   final TabSelectInterceptor? tabSelectInterceptor;
   final bool selectToEnableButtons;

--- a/lib/src/tab_widget.dart
+++ b/lib/src/tab_widget.dart
@@ -14,11 +14,10 @@ import 'package:tabbed_view/src/theme/tab_theme_data.dart';
 import 'package:tabbed_view/src/theme/tabbed_view_theme_data.dart';
 import 'package:tabbed_view/src/theme/theme_widget.dart';
 
-/// Listener for the tabs with the mouse over.
 typedef UpdateHighlightedIndex = void Function(int? tabIndex);
 
-/// The tab widget. Displays the tab text and its buttons.
 class TabWidget extends StatelessWidget {
+  /// The tab widget. Displays the tab text and its buttons.
   const TabWidget(
       {required UniqueKey key,
       required this.index,
@@ -31,6 +30,8 @@ class TabWidget extends StatelessWidget {
   final int index;
   final TabStatus status;
   final TabbedViewProvider provider;
+
+  /// Listener for the tabs with the mouse over.
   final UpdateHighlightedIndex updateHighlightedIndex;
   final Function onClose;
 
@@ -250,7 +251,7 @@ class TabWidget extends StatelessWidget {
       }
       TabButton closeButton = TabButton(
           icon: tabTheme.closeIcon,
-          onPressed: () => _onClose(context, index),
+          onPressed: () async => await _onClose(context, index),
           toolTip: provider.closeButtonTooltip);
 
       textAndButtons.add(Container(
@@ -272,9 +273,19 @@ class TabWidget extends StatelessWidget {
     return textAndButtons;
   }
 
-  void _onClose(BuildContext context, int index) {
-    if (provider.tabCloseInterceptor == null ||
-        provider.tabCloseInterceptor!(index)) {
+  Future<void> _onClose(BuildContext context, int index) async {
+    bool? DialogReturnedPositive;
+    if (provider.tabCloseConfirmationDialogBuilder != null) {
+      DialogReturnedPositive = (await showDialog<bool>(
+              barrierDismissible: false,
+              context: context,
+              builder: (context) => provider.tabCloseConfirmationDialogBuilder!(
+                  context, index, provider.controller.getTabByIndex(index)))) ??
+          false;
+    }
+    if ((DialogReturnedPositive ?? true) &&
+        (provider.tabCloseInterceptor == null ||
+            provider.tabCloseInterceptor!(index))) {
       onClose();
       TabData tabData = provider.controller.removeTab(index);
       if (provider.onTabClose != null) {

--- a/lib/src/tabbed_view.dart
+++ b/lib/src/tabbed_view.dart
@@ -14,31 +14,29 @@ import 'package:tabbed_view/src/typedefs/on_before_drop_accept.dart';
 import 'package:tabbed_view/src/typedefs/on_draggable_build.dart';
 import 'package:tabbed_view/src/typedefs/can_drop.dart';
 
-/// Tabs area buttons builder
 typedef TabsAreaButtonsBuilder = List<TabButton> Function(
     BuildContext context, int tabsCount);
 
-/// The event that will be triggered after the tab close.
 typedef OnTabClose = void Function(int tabIndex, TabData tabData);
 
-/// Intercepts a close event to indicates whether the tab can be closed.
 typedef TabCloseInterceptor = bool Function(int tabIndex);
 
-/// Intercepts a select event to indicate whether the tab can be selected.
+typedef TabCloseConfirmationDialogBuilder = Widget Function(
+    BuildContext context, int tabIndex, TabData tabData);
+
 typedef TabSelectInterceptor = bool Function(int newTabIndex);
 
-/// Event that will be triggered when the tab selection is changed.
 typedef OnTabSelection = Function(int? newTabIndex);
 
-/// Widget inspired by the classic Desktop-style tab component.
-///
-/// Supports customizable themes.
-///
-/// Parameters:
-/// * [selectToEnableButtons]: allows buttons to be clicked only if the tab is
-///   selected. The default value is [TRUE].
-/// * [closeButtonTooltip]: optional tooltip for the close button.
 class TabbedView extends StatefulWidget {
+  /// Widget inspired by the classic Desktop-style tab component.
+  ///
+  /// Supports customizable themes.
+  ///
+  /// Parameters:
+  /// * [selectToEnableButtons]: allows buttons to be clicked only if the tab is
+  ///   selected. The default value is [TRUE].
+  /// * [closeButtonTooltip]: optional tooltip for the close button.
   TabbedView(
       {required this.controller,
       this.contentBuilder,
@@ -46,6 +44,7 @@ class TabbedView extends StatefulWidget {
       this.tabCloseInterceptor,
       this.onTabSelection,
       this.tabSelectInterceptor,
+      this.tabCloseConfirmationDialogBuilder,
       this.selectToEnableButtons = true,
       this.contentClip = true,
       this.closeButtonTooltip,
@@ -58,12 +57,31 @@ class TabbedView extends StatefulWidget {
   final TabbedViewController controller;
   final bool contentClip;
   final IndexedWidgetBuilder? contentBuilder;
+
+  /// The event that will be triggered after the tab close.
   final OnTabClose? onTabClose;
+
+  /// Intercepts a close event to indicates whether the tab can be closed.
+  ///
+  /// if [tabCloseConfirmationDialogBuilder] is not null, then thisfunction iscalled after the dialog is dismissed.
   final TabCloseInterceptor? tabCloseInterceptor;
+
+  /// a function that returns a widget that will be displayed as a non-dismissable dialog when attempting to close a tab.
+  ///
+  /// the dialog widget should call `navigator.of(context).pop<bool>()` at some point to exit the dialog and return a response to the tab widget, returning `false` will dissmiss the close action.
+  ///
+  /// asynchrenous workflows can be used inside the dialog widget, but ensure that they are awaited before navigating back.
+  final TabCloseConfirmationDialogBuilder? tabCloseConfirmationDialogBuilder;
+
+  /// Event that will be triggered when the tab selection is changed.
   final OnTabSelection? onTabSelection;
+
+  /// Intercepts a select event to indicate whether the tab can be selected.
   final TabSelectInterceptor? tabSelectInterceptor;
   final bool selectToEnableButtons;
   final String? closeButtonTooltip;
+
+  /// Tabs area buttons builder
   final TabsAreaButtonsBuilder? tabsAreaButtonsBuilder;
   final bool? tabsAreaVisible;
   final OnDraggableBuild? onDraggableBuild;
@@ -74,7 +92,6 @@ class TabbedView extends StatefulWidget {
   State<StatefulWidget> createState() => _TabbedViewState();
 }
 
-/// The [TabbedView] state.
 class _TabbedViewState extends State<TabbedView> {
   int? _lastSelectedIndex;
   List<TabbedViewMenuItem> _menuItems = [];
@@ -106,6 +123,8 @@ class _TabbedViewState extends State<TabbedView> {
         contentBuilder: widget.contentBuilder,
         onTabClose: widget.onTabClose,
         tabCloseInterceptor: widget.tabCloseInterceptor,
+        tabCloseConfirmationDialogBuilder:
+            widget.tabCloseConfirmationDialogBuilder,
         onTabSelection: widget.onTabSelection,
         contentClip: widget.contentClip,
         tabSelectInterceptor: widget.tabSelectInterceptor,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,50 +5,50 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -71,18 +71,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -119,71 +119,71 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
@@ -196,10 +196,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.1"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
fix some missplaced documentation comments.
add `TabCloseConfirmationDialogBuilder` property.
make closing tab an asynchronous operation that awaits a response from a dialog that is shos if `TabCloseConfirmationDialogBuilder` is not null, otherwise it follows same previous behaviour. `TabCloseConfirmationDialogBuilder` is executed before `tabCloseInterceptor`.

the dialog is made non-dismiss-able to minimize possibility of triggering multiple asynchronous calls before previous ones are completed. 

this is meant as an alternative solution to pull request #50 in case you are still skeptical of it.